### PR TITLE
fix for dataset that don't have metadata

### DIFF
--- a/src/views/Dataset-info.vue
+++ b/src/views/Dataset-info.vue
@@ -26,11 +26,11 @@
                     </div>
 
                     <v-row class="mt-0">
-                        <div class="col-6">
+                        <div v-if="dataset.foundry.domain" class="col-6">
                             <h3><i class="mdi mdi-beaker-outline red--text text--lighten-3"></i> Scientific Domain</h3>
                             <p>{{ dataset.foundry.domain[0] }} </p>
                         </div>
-                        <div class="col-6">
+                        <div class="col-6" v-if="dataset.foundry.task_type">
                             <h3><i class="mdi mdi-run red--text text--lighten-3"></i> Associated Tasks</h3>
                             <v-chip color="indigo lighten-2" outlined class="mx-1"
                                 v-for="task in dataset.foundry.task_type" :key="task">
@@ -39,7 +39,7 @@
                         </div>
                     </v-row>
                     <v-row class="mt-0">
-                        <div class="col-6">
+                        <div v-if="dataset.foundry.data_type" class="col-6">
                             <h3><i class="mdi mdi-chart-bar red--text text--lighten-3"></i> Data Type</h3>
                             <p>{{ dataset.foundry.data_type }}</p>
                         </div>
@@ -173,8 +173,8 @@ res = f.load_data()
                         </template>
                     </v-simple-table>
 
-                    <h3>Splits</h3>
-                    <v-simple-table dense class="col-12 mb-10">
+                    <h3 v-if="dataset.foundry.splits">Splits</h3>
+                    <v-simple-table dense class="col-12 mb-10" v-if="dataset.foundry.splits">
                         <template v-slot:default>
                             <thead>
                                 <tr>
@@ -246,9 +246,13 @@ export default {
 
                 var creators = res.data.gmeta[0].entries[0].content.dc.creators
                 var authors = []
+                var foundry = {}
 
                 for (let i = 0; i < creators.length; i++) {
                     authors.push(creators[i].creatorName)
+                }
+                if(res.data.gmeta[0].entries[0].content.projects && res.data.gmeta[0].entries[0].content.projects.foundry){
+                    foundry = res.data.gmeta[0].entries[0].content.projects.foundry
                 }
 
                 // TODO, add more data into the view object for display
@@ -256,7 +260,7 @@ export default {
                     title: res.data.gmeta[0].entries[0].content.dc.titles[0].title,
                     authors: authors,
                     dc: res.data.gmeta[0].entries[0].content.dc,
-                    foundry: res.data.gmeta[0].entries[0].content.projects.foundry,
+                    foundry: foundry,
                     to: "/datasets/" + res.data.gmeta[0].entries[0].content.mdf.source_id,
                     data_info: res.data.gmeta[0].entries[0].content.data
                 }
@@ -272,14 +276,22 @@ export default {
     }),
     computed: {
         inputFilter(){
-            return this.dataset.foundry.keys.filter((item) => {
-                return item.type === "input"
-            })
+            if(this.dataset.foundry.keys){
+                return this.dataset.foundry.keys.filter((item) => {
+                    return item.type === "input"
+                })
+            }else{
+                return ""
+            }
         },
         targetFilter(){
-            return this.dataset.foundry.keys.filter((item) => {
-                return item.type === "target"
-            })
+            if(this.dataset.foundry.keys){
+                return this.dataset.foundry.keys.filter((item) => {
+                    return item.type === "target"
+                })
+            }else{
+                return ""
+            }
         }
     }
 }

--- a/src/views/Datasets.vue
+++ b/src/views/Datasets.vue
@@ -105,14 +105,14 @@
                                 </div>
                                 
                                 <div>
-                                    <v-chip class="ma-2" color="blue lighten-1" text-color="white">
+                                    <v-chip v-if="item.foundry.data_type" class="ma-2" color="blue lighten-1" text-color="white">
                                         {{ item.foundry.data_type }}
                                     </v-chip>
                                    
-                                    <v-chip class="ma-2" color="red lighten-2" text-color="white">
+                                    <v-chip v-if="item.foundry.task_type" class="ma-2" color="red lighten-2" text-color="white">
                                         {{ item.foundry.task_type[0] }}
                                     </v-chip>
-                                     <v-chip class="ma-2" color="indigo lighten-3" text-color="white">
+                                     <v-chip v-if="item.foundry.n_items" class="ma-2" color="indigo lighten-3" text-color="white">
                                         {{ item.foundry.n_items }} Items
                                     </v-chip>
                                 </div>
@@ -184,6 +184,10 @@ export default {
                 var creators = res.data.gmeta[i].entries[0].content.dc.creators;
                 var authors = [];
                 var dataset_link = "";
+                var foundry = {}
+                if(res.data.gmeta[i].entries[0].content.projects && res.data.gmeta[i].entries[0].content.projects.foundry){
+                    foundry = res.data.gmeta[i].entries[0].content.projects.foundry;
+                }
                 for (let j = 0; j < creators.length; j++) {
                     authors.push(creators[j].creatorName);
                 }
@@ -196,7 +200,7 @@ export default {
                 }
                 self.items.push({
                     "title": res.data.gmeta[i].entries[0].content.dc.titles[0].title,
-                    "foundry": res.data.gmeta[i].entries[0].content.projects.foundry,
+                    "foundry": foundry,
                     "dc": res.data.gmeta[i].entries[0].content.dc,
                     "authors": authors,
                     "to": dataset_link
@@ -282,10 +286,12 @@ export default {
         filteredItems() {
             if (this.input === "") {
                 return this.items.filter((item) => {
-                    if(item.dc.dates){
+                    if(item.dc.dates && item.foundry.task_type){
                         return this.yearsInput.includes(item.dc.dates[0].date.slice(0, 4)) && this.taskTypeInput.includes(item.foundry.task_type[0]) && this.dataTypeInput.includes(item.foundry.data_type);
-                    }else{
+                    }else if(item.foundry.task_type){
                         return this.taskTypeInput.includes(item.foundry.task_type[0]) && this.dataTypeInput.includes(item.foundry.data_type);
+                    }else{
+                        return true
                     }
                 });
             }
@@ -316,19 +322,35 @@ export default {
         },
         taskType() {
             let task = this.items.map((item) => {
-                return item.foundry.task_type[0];
+                if(item.foundry.task_type){
+                    return item.foundry.task_type[0];
+                }else{
+                    return ""
+                }
             }).filter(function (value, index, arr) {
                 return index === arr.indexOf(value);
             });
+            const index = task.indexOf("")
+            if(index>-1){
+                task.splice(index, 1)
+            }
             this.taskTypeInput = task;
             return task;
         },
         dataType() {
             let data = this.items.map((item) => {
-                return item.foundry.data_type;
+                if(item.foundry.data_type){
+                    return item.foundry.data_type;
+                }else{
+                    return ""
+                }
             }).filter(function (value, index, arr) {
-                return index === arr.indexOf(value);
+                return index === arr.indexOf(value) && value !== "";
             });
+            const index = data.indexOf("")
+            if(index>-1){
+                data.splice(index, 1)
+            }
             this.dataTypeInput = data;
             return data;
         }


### PR DESCRIPTION
Added a fix to ensure that if metadata is missing (in this case all foundry metadata), things still get rendered. Should help if test datasets make it to production and for future metadata structure changes